### PR TITLE
Remove dependency up-to-date check

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -124,41 +124,7 @@ jobs:
           name: Android instrumented test results
           path: '**/*.xml'
           reporter: java-junit
-
-  checkDependencies:
-    name: Check Android dependencies
-    runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      pull-requests: write
-
-    defaults:
-      run:
-        working-directory: android
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: $(( ${{ github.event_name == 'pull_request' && github.event.pull_request.commits || 0 }} + 1 ))
-      - name: Get changed Android files
-        id: changed-files
-        uses: tj-actions/changed-files@v46
-        with:
-          files: android/**
-      - name: Note if Android files not changed
-        if: steps.changed-files.outputs.any_changed != 'true'
-        run: echo "Android is not affected"
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        if: steps.changed-files.outputs.any_changed == 'true'
-        with:
-          java-version: 17
-          distribution: "temurin"
-      - name: Check for out-of-date dependencies
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: ./gradlew useLatestVersions && git diff && git diff-files --quiet --exit-code
-
+  
   checkBuildHealth:
     name: Check Android build health
     runs-on: ubuntu-latest


### PR DESCRIPTION
It was meant to be a non-blocking heads up, but it actually just creates noise everywhere and marks every build as failed. Going to deal with this otherwise (perhaps by a weekly scheduled check, once dependabot is expected to be working in general)