### PR TITLE
Specify toolchain more loosely

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -150,7 +150,9 @@ android {
     namespace = "com.thebluefolderproject.leafbyte"
 
     kotlin {
-        jvmToolchain(17)
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
     }
 
     tasks.withType<JacocoReport> {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -150,7 +150,7 @@ android {
     namespace = "com.thebluefolderproject.leafbyte"
 
     kotlin {
-        toolchain {
+        jvmToolchain {
             languageVersion = JavaLanguageVersion.of(17)
         }
     }


### PR DESCRIPTION
Previously we were requiring JDK 17, but now we're allowing anything that can compile as/to JDK 17