### PR TITLE
Ignore publicClassesClasspath lockfile

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -64,6 +64,7 @@ allprojects {
                 "combinedGraphClasspath",
                 "projectMetadataClasspath",
                 "projectHealthClasspath",
+                "publicClassesClasspath",
                 "releaseUnitTestCompileClasspath",
                 "resolvedDepsClasspath",
                 "swiftExportClasspathResolvable",

--- a/android/openCVLibrary343/gradle.lockfile
+++ b/android/openCVLibrary343/gradle.lockfile
@@ -1,4 +1,5 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+# To regenerate this file, run: ./gradlew :openCVLibrary343:dependencies --write-locks
 empty=debugAndroidTestAnnotationProcessorClasspath,debugAndroidTestCompileClasspath,debugAndroidTestLintChecksClasspath,debugAndroidTestRuntimeClasspath,debugAnnotationProcessorClasspath,debugCompileClasspath,debugLintChecksClasspath,debugRuntimeClasspath,debugUnitTestAnnotationProcessorClasspath,debugUnitTestCompileClasspath,debugUnitTestLintChecksClasspath,debugUnitTestRuntimeClasspath,releaseAnnotationProcessorClasspath,releaseCompileClasspath,releaseLintChecksClasspath,releaseRuntimeClasspath,releaseUnitTestAnnotationProcessorClasspath,releaseUnitTestRuntimeClasspath


### PR DESCRIPTION
There's no lockfile generatable for this, but renovate is failing because it doesn't have a lockfile. Hopefully this makes our renovate go back to generating lockfiles