### PR TITLE
Remove unused secrets version

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -70,4 +70,3 @@ kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "ko
 kotlin-gradle = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin-version" }
 ktlint = "org.jlleitschuh.gradle.ktlint:14.2.0"
 protobuf = "com.google.protobuf:0.10.0"
-secrets = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:2.0.1"


### PR DESCRIPTION
This has not yet been properly switched to the version file, and Renovate is throwing errors on this