### PR TITLE
Skip dependencyAnalysisKotlinMetadataClasspath lockfile

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -62,6 +62,7 @@ allprojects {
         val configurationsThatCantBeLocked =
             arrayOf(
                 "combinedGraphClasspath",
+                "dependencyAnalysisKotlinMetadataClasspath",
                 "projectMetadataClasspath",
                 "projectHealthClasspath",
                 "publicClassesClasspath",


### PR DESCRIPTION
There's nothing to put in here, but the lack of lockfile breaks the new dep analysis plugin if we don't ignore it

```
      "stderr": "Command failed: ./gradlew -Dorg.gradle.jvmargs=-Xms512m -Xmx512m --console=plain --dependency-verification lenient -q :dependencies :app:dependencies :openCVLibrary343:dependencies --update-locks com.autonomousapps.dependency-analysis:com.autonomousapps.dependency-analysis.gradle.plugin\n\nFAILURE: Build failed with an exception.\n\n* What went wrong:\nConfiguration cache state could not be cached: field `resolutionResultRoot` of `org.gradle.api.tasks.diagnostics.internal.ConfigurationDetails` bean found in field `configurations` of `org.gradle.api.tasks.diagnostics.AbstractDependencyReportTask$DependencyReportModel` bean found in field `modelsByProjectDetails` of `org.gradle.api.tasks.diagnostics.AbstractProjectBasedReportTask$ProjectBasedReportModel` bean found in field `value` of `org.gradle.internal.Try$Success` bean found in field `result` of `org.gradle.internal.serialization.Cached$Fixed` bean found in field `reportModels` of task `:dependencies` of type `org.gradle.api.tasks.diagnostics.DependencyReportTask`: error writing value of type 'org.gradle.api.internal.provider.DefaultProvider'\n> Could not resolve all dependencies for configuration ':dependencyAnalysisKotlinMetadataClasspath'.\n   > Locking strict mode: Configuration ':dependencyAnalysisKotlinMetadataClasspath' is locked but does not have lock state.\n\n* Try:\n> To create the lock state, run a task that performs dependency resolution and add '--write-locks' to the command line.\n> For more information on generating lock state, please refer to https://docs.gradle.org/9.6.1/userguide/dependency_locking.html#generating_and_updating_dependency_locks in the Gradle documentation.\n> Run with --stacktrace option to get the stack trace.\n> Run with --info or --debug option to get more log output.\n> Run with --scan to get full insights from a Build Scan (powered by Develocity).\n> Get more help at https://help.gradle.org.\n\nBUILD FAILED in 1m 45s\n"
```